### PR TITLE
fix: customizable VM_NAME

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -7,6 +7,10 @@ includes:
 variables:
   - name: ARCH
     default: "${UDS_ARCH}"
+  - name: VM_NAME
+    default: "rke2"
+  - name: LIMA_ARGS
+    default: "--memory 20 --cpus 10"
 
 tasks:
   - name: default
@@ -34,24 +38,24 @@ tasks:
     description: "Build prereqs Zarf package"
     actions:
       - description: "Build package with RKE2 prereqs"
-        cmd: "./uds zarf p c -a ${ARCH} --confirm --no-progress --skip-sbom"
+        cmd: "./uds zarf package create -a ${ARCH} --confirm --no-progress --skip-sbom"
 
   - name: create-lima-vm
     description: "Creates Lima RKE2 VM"
     actions:
       - cmd: |
           if [[ "$(uname)" == "Darwin" ]]; then
-            limactl start template://experimental/rke2 \
-              --memory 20 --cpus 10 --vm-type=vz --network=vzNAT -y
+            limactl start --name="$VM_NAME" template://experimental/rke2 \
+              --vm-type=vz --network=vzNAT -y $LIMA_ARGS
           else
-            limactl start template://experimental/rke2 \
-              --memory 20 --cpus 10 --vm-type=qemu -y
+            limactl start --name="$VM_NAME" template://experimental/rke2 \
+              --vm-type=qemu -y $LIMA_ARGS
           fi
   - name: deploy
     description: "Deploys rke2-core-demo bundle"
     actions:
       - cmd: |
-          export KUBECONFIG=$(limactl list rke2 --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
+          export KUBECONFIG=$(limactl list --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml' -- "$VM_NAME")
           ./uds deploy uds-bundle-uds-rke2-demo-*.tar.zst --confirm
 
   - name: print-kubeconfig-path
@@ -59,36 +63,31 @@ tasks:
     actions: 
       - cmd: |
           echo  "****** Export the following env var to connect to cluster (Lima VM only!) ****** "
-          echo export KUBECONFIG=$(limactl list rke2 --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml')
+          echo export KUBECONFIG=$(limactl list --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml' -- "$VM_NAME")
           echo "\n"
 
   - name: delete-lima-vm
     description: "Deletes Lima VM"
     actions:
       - cmd: |
-          VM_NAME="rke2"
-
-          vm_line="$(limactl list 2>/dev/null | awk -v vm="$VM_NAME" '$1==vm {print}')"
-
-          if [ -z "${vm_line}" ]; then
+          if ! vm_status="$(limactl list --format '{{.Status}}' -- "${VM_NAME}" 2>/dev/null)"; then
             echo "VM '${VM_NAME}' does not exist."
             exit 0
           fi
 
-          # If the second column says Running, stop it
-          vm_status="$(echo "${vm_line}" | awk '{print $2}')"
           if [ "${vm_status}" = "Running" ]; then
-            echo "Stopping ${VM_NAME}..."
-            limactl stop "${VM_NAME}" || true
+            echo "Stopping '${VM_NAME}''..."
+            limactl stop -- "${VM_NAME}" || true
           fi
 
-          echo "Deleting ${VM_NAME}..."
-          limactl delete -f "${VM_NAME}" || limactl delete "${VM_NAME}"
+          echo "Deleting '${VM_NAME}'..."
+          limactl delete -f -- "${VM_NAME}" || limactl delete -- "${VM_NAME}"
 
   - name: get-gw-ips
     actions:
       - description: Print ingress gateway IPs
         cmd: |
+          export KUBECONFIG=$(limactl list --format 'unix://{{.Dir}}/copied-from-guest/kubeconfig.yaml' -- "$VM_NAME")
           echo "*** Admin Gateway IP ***"
           ./uds zarf tools kubectl get svc admin-ingressgateway -n istio-admin-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
           echo "\n*** Tenant Gateway IP ***"
@@ -100,8 +99,8 @@ tasks:
       - description: Build and deploy podinfo as an example mission app
         dir: podinfo
         cmd: |
-          ./uds zarf p c --confirm
-          ./uds zarf p d zarf-package-podinfo-*.tar.zst --confirm
+          ./uds zarf package create --confirm
+          ./uds zarf package deploy zarf-package-podinfo-*.tar.zst --confirm
 
   - name: clean
     actions:


### PR DESCRIPTION
Support customizing Lima VM name, providing initial multi-cluster support.

This is enough to deploy two clusters on one computer. Per-cluster configuration is needed (like a unique domain per cluster and certificates) can be done with `uds-config.yaml`. 

Usage:
```
uds run --set VM_NAME=cluster-a

# First, edit uds-config.yaml for cluster-b
uds run --set VM_NAME=cluster-b
```

There is one bug however: both VMs port forward 127.0.0.1:6443. If you manually edit the kubeconfig to be the vzNAT IP kubectl will work fine however (not sure how this behaves on qemu):
```
# brittle parsing here, really should look for "via":
limactl shell "$VM_NAME" ip route show 0.0.0.0/0 | head -n1 | cut -d' ' -f 9
```
(maybe we could make an upstream PR to the lima template about this? Or add the fix to this PR.)